### PR TITLE
Coverage for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ language: node_js
 node_js:
   - "node"
 after_success:
-  - 'cat ./coverage/lcov.info | ./node_modules/.bin/coveralls'
+    - npm run coverage
+    - ./node_modules/.bin/coveralls < ./coverage/lcov.info
+    - rm -rf ./coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - "node"
+  - "6"
+  - "8"
 after_success:
     - npm run coverage
     - ./node_modules/.bin/coveralls < ./coverage/lcov.info

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "build": "BABEL_ENV=build babel js -d lib",
     "coverage": "babel-node ./node_modules/.bin/babel-istanbul cover _mocha --report lcovonly -- -R spec",
     "lint": "node_modules/.bin/eslint js",
-    "posttest": "npm run coverage",
+    "posttest": "[ -z \"$npm_config_coverage\" ] || babel-istanbul check-coverage --branches 80 --functions 80 --lines 80 --statements 80",
     "prepare": "npm run build",
     "prepublishOnly": "npm run securityCheck && npm test --coverage",
     "pretest": "npm run lint",


### PR DESCRIPTION
Adds two separate npm scripts for providing test coverage information:

* `posttest`: if `npm test` is invoked with the `--coverage` flag, babel-istanbul will both generate an HTML coverage report (useful for individual developers seeking to ensure good coverage on their own working copies,) and enforce coverage minimums (currently set to 80% for all categories.) If the coverage minimums are not met, `npm test --coverage` will fail. Because this is invoked by `prepublishOnly`, it prevents any version of the project with poor test coverage from being published to npm by accident.

* coverage: This is an abbreviated run of babel-istanbul intended for coverage-related CI services like Coveralls. It does not generate the full HTML coverage report, and does not enforce coverage minimums. It just creates the lcov.info file required by coverage reporting services during/after CI builds.

The `travis.yml` file has been updated to make use of this and clean up after itself once done.

Additionally, while Node 6 remains the LTS release of Node.js, it is prudent to ensure that tests run and pass on both it and the latest stable (currently Node 8). TravisCI will run these two builds in parallel and report on the success or failure of each.