### PR TITLE
Amend request-endpoint fields test

### DIFF
--- a/test/request-endpoint.js
+++ b/test/request-endpoint.js
@@ -47,15 +47,16 @@ describe('request-endpoint', () => {
                 'X-Mashape-Key': headerValue => headerValue
             }
         }).get('/games/').query({
-            fields: 'id,name'
+            fields: 'id,name',
+            limit: 1
         }).reply(200, _response);
 
         return igdb(configuration.api.key).games({
-            fields: [
-                'id',
-                'name'
-            ]
-        }).then(response => {
+            limit: 1
+        }, [
+            'id',
+            'name'
+        ]).then(response => {
             expect(response.body).to.eql(_response);
         });
     });


### PR DESCRIPTION
The original test passed fields as a property on the `options` object.
It has been changed to use the `fields` argument to the client endpoint
method instead.