### PR TITLE
Full Test Coverage!

### DIFF
--- a/js/perform-request.js
+++ b/js/perform-request.js
@@ -1,6 +1,6 @@
 /* eslint no-process-env: 0 */
 import config from '../configuration';
-import request from 'request';
+import request from './request-promise';
 
 /**
  * Sends a HTTP request to the provided URL.
@@ -10,7 +10,7 @@ import request from 'request';
  * @example
  * performRequest('http://example.com/api/v1/exampleEndpoint', 'example-api-key-123').then(console.log)
  */
-export default (url, apiKey) => new Promise((resolve, reject) => {
+export default (url, apiKey) => {
     const options = {
         headers: {
             Accept: 'application/json'
@@ -34,19 +34,9 @@ export default (url, apiKey) => new Promise((resolve, reject) => {
     options.headers[config.api.keyHeader] = apiKey;
 
     // Send the request to the API
-    request(options, (error, response, body) => {
-        if (!error) {
-            /*
-            Even if there is no error from the request itself, there
-            might still be an HTTP error in the response.
-            */
-            error = response.statusCode === 200 ?
-                null :
-                new Error(`HTTP Status ${response.statusCode} - ${options.url}`);
-        }
-
-        if (error) {
-            reject(error);
+    return request(options).then(result => new Promise((resolve, reject) => {
+        if (result.response.statusCode !== 200) {
+            reject(new Error(`HTTP Status ${result.response.statusCode} - ${options.url}`));
             return;
         }
 
@@ -67,5 +57,5 @@ export default (url, apiKey) => new Promise((resolve, reject) => {
             // JSON.parse() error
             reject(error);
         }
-    });
-});
+    }));
+};

--- a/js/perform-request.js
+++ b/js/perform-request.js
@@ -50,7 +50,7 @@ export default (url, apiKey) => {
                 body: JSON.parse(result.body),
                 headers: result.response.headers,
                 scrollCount: result.response.headers['x-count'] || result.response.headers['X-Count'],
-                scrollUrl: result.response.headers['x-next-page'] || result.response.headers['X-Next Page'],
+                scrollUrl: result.response.headers['x-next-page'] || result.response.headers['X-Next-Page'],
                 url: options.url
             });
         } catch (error) {

--- a/js/perform-request.js
+++ b/js/perform-request.js
@@ -47,10 +47,10 @@ export default (url, apiKey) => {
             and it throws an Error.
             */
             resolve({
-                body: JSON.parse(body),
-                headers: response.headers,
-                scrollCount: response.headers['X-Count'],
-                scrollUrl: response.headers['X-Next-Page'],
+                body: JSON.parse(result.body),
+                headers: result.response.headers,
+                scrollCount: result.response.headers['x-count'] || result.response.headers['X-Count'],
+                scrollUrl: result.response.headers['x-next-page'] || result.response.headers['X-Next Page'],
                 url: options.url
             });
         } catch (error) {

--- a/js/request-promise.js
+++ b/js/request-promise.js
@@ -1,0 +1,23 @@
+import presage from 'presage';
+import request from 'request';
+
+export default url => {
+    const {
+        callbackFunction,
+        promise
+    } = presage.promiseWithCallback();
+
+    request(url, (error, response, body) => {
+        if (error) {
+            callbackFunction(error);
+            return;
+        }
+
+        callbackFunction(null, {
+            body,
+            response
+        });
+    });
+
+    return promise;
+};

--- a/js/request-promise.js
+++ b/js/request-promise.js
@@ -1,6 +1,11 @@
 import presage from 'presage';
 import request from 'request';
 
+/**
+ * A Promise-based wrapper for `request`.
+ * @arg {string} url An HTTP url.
+ * @returns {Promise<Object>} An object containing the response object and response body.
+ */
 export default url => {
     const {
         callbackFunction,

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   ],
   "dependencies": {
     "babel-runtime": "^6.23.0",
+    "presage": "^0.1.4",
     "request": "^2.60.0"
   },
   "description": "Nodejs API Wrapper for IGDB.com",

--- a/test/perform-request.js
+++ b/test/perform-request.js
@@ -51,4 +51,20 @@ describe('perform-request', () => {
             expect(error).to.be.an.instanceOf(Error).with.property('message', 'HTTP Status 404 - http://example.com/api/v1/exampleEndpoint');
         });
     });
+
+    it('should return a rejected Promise if the URI provides malformed JSON', () => {
+        nock('http://example.com/api/v1', {
+            reqheaders: {
+                Accept: 'application/json',
+                'X-Mashape-Key': headerValue => {
+                    expect(headerValue).to.equal('example-api-key-123');
+                    return headerValue;
+                }
+            }
+        }).get('/exampleEndpoint').reply(200, 'this-is-not-json');
+
+        return performRequest('http://example.com/api/v1/exampleEndpoint', 'example-api-key-123').catch(error => {
+            expect(error).to.be.an.instanceOf(Error).with.property('message', 'Unexpected token h in JSON at position 1');
+        });
+    });
 });

--- a/test/request-promise.js
+++ b/test/request-promise.js
@@ -1,0 +1,54 @@
+import {
+    describe,
+    it
+} from 'mocha';
+
+import {
+    expect
+} from 'chai';
+
+import request from '../js/request-promise';
+
+const testUrl = 'http://localhost:0/asdf';
+
+describe('request-promise', () => {
+    it('should reject when called without a url', () => request({}).catch(error => {
+        expect(error).to.be.an.instanceOf(Error).with.property('message', 'options.uri is a required argument');
+    }));
+
+    it('should reject when called with an invalid url', () => request({
+        url: 'this-is-not-a-valid-url'
+    }).catch(error => {
+        expect(error).to.be.an.instanceOf(Error).with.property('message', 'Invalid URI "this-is-not-a-valid-url"');
+    }));
+
+    it('should reject when called with a url that is missing a protocol', () => request({
+        url: 'example.com/url-is-not-valid-without-protocol'
+    }).catch(error => {
+        expect(error).to.be.an.instanceOf(Error).with.property('message', 'Invalid URI "example.com/url-is-not-valid-without-protocol"');
+    }));
+
+    it('should reject when called with an invalid url and environmental NO_PROXY variable is set', () => {
+        process.env.NO_PROXY = 'google.com';
+
+        return request({
+            url: 'invalid'
+        }).catch(error => {
+            expect(error).to.be.an.instanceOf(Error).with.property('message', 'Invalid URI "invalid"');
+            delete process.env.NO_PROXY;
+        });
+    });
+
+    it('should reject when called with a deprecated UNIX url', () => request({
+        uri: 'unix://path/to/socket/and/then/request/path'
+    }).catch(error => {
+        expect(error).to.be.an.instanceOf(Error).with.property('message', '`unix://` URL scheme is no longer supported. Please use the format `http://unix:SOCKET:PATH`');
+    }));
+
+    it('should reject when called with invalid body', () => request({
+        body: {},
+        url: testUrl
+    }).catch(error => {
+        expect(error).to.be.an.instanceOf(Error).with.property('message', 'Argument error, options.body.');
+    }));
+});


### PR DESCRIPTION
The last bit of remaining test coverage was annoying me, so I decided to see to it.

Changes:
- Promisify the `request` module: The `request` module was the only remaining bit of logic in this module that used callback-style async instead of Promises. Using my [`presage` Promise utility](https://github.com/dsibilly/presage), it has been wrapped in a new module that returns a Promise. The new Promise returned by `request-promise` is returned directly by the `perform-request` module.
This replaces request calls like this:
```javascript
request({
    url: 'http://example.com/api/v1/imaginaryEndpoint'
}, (error, response, body) => {
    /* handle error, process response, etc. */
});
```
...with...
```javascript
request({
    url: 'http://example.com/api/v1/imaginaryEndpoint'
}).then(result => {
    const {
        body,
        response
    } = result;

    /* process response & body */
}).catch(error => {
    /* handle error */
});
```
- Unit tests have been added to cover `request-promise` to make certain that various errors are thrown/rejected as intended should it be provided with improper arguments.
- `perform-request` now has a unit test to ensure it returns a rejected Promise if `JSON.parse()` fails due to a malformed API response.
- The `scroll` method remained the only client method not subject to unit testing. Using the [API documentation](https://igdb.github.io/api/references/pagination/) for pagination, a new unit test has been devised to ensure that it behaves as intended. Creating this test revealed a possible bug in the way the scroll count and scroll URL were parsed out of the API response headers. The logic will now attempt to use the lowercase header names first, and then the Initial Case header names if the lowercase ones are not present in the response object.

These changes have brought test coverage to 100%. 😇