### PR TITLE
WIP: response scroll

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,4 +1,4 @@
-/* eslint no-process-env: 0 */
+/* eslint no-process-env: 0, no-console: 0 */
 import config from '../configuration';
 import endpoints from './endpoints';
 import getImage from './get-image';
@@ -19,7 +19,16 @@ export default apiKey => endpoints.reduce((endpointObj, endpoint) => {
     return endpointObj;
 }, {
     image: getImage,
-    scroll: url => performRequest(url, apiKey)
+    /**
+     * Performs a client request on an arbitrary URL. Intended for use with scrolling paginated results.
+     * @arg {string} url
+     * @returns {Promise<Object>}
+     * @deprecated since version 3.1.0
+     */
+    scroll: url => {
+        console.log('The client.scroll function is deprecated and will be removed in v4.0.0');
+        return performRequest(url, apiKey);
+    }
 });
 
 export {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -48,7 +48,7 @@ describe('Helper Methods', () => {
     });
 
     describe('client.scroll', () => {
-        it('should retrive next page of results via scrollUrl and client.scroll', () => {
+        it('should retrive next page of results via scrollUrl and client.scroll (DEPRECATED v3.1.0)', () => {
             nock(igdbApiUrl, {
                 reqheaders: {
                     Accept: 'application/json',


### PR DESCRIPTION
Adds a `scroll` method to response objects that are scroll-enabled (i.e. contain a truthy `scrollUrl` property.) Deprecates the `client.scroll` method for eventual removal in v4.0.0.

Addresses #14.

